### PR TITLE
feat: add GET/LIST integration test with mock gRPC; clap listen-address; set store_type=memory; bump sbe to 0.1.2

### DIFF
--- a/.output.txt
+++ b/.output.txt
@@ -1,0 +1,216 @@
+/home/paul/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/suppaftp-6.2.0/src/lib.rs:199:pub type AsyncFtpStream = ImplAsyncFtpStream<AsyncNoTlsStream>;
+/home/paul/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/suppaftp-6.2.0/src/sync_ftp/mod.rs:418:    pub fn retr<F, D>(&mut self, file_name: &str, mut reader: F) -> FtpResult<D>
+/home/paul/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/suppaftp-6.2.0/src/sync_ftp/mod.rs:447:    pub fn retr_as_buffer(&mut self, file_name: &str) -> FtpResult<Cursor<Vec<u8>>> {
+/home/paul/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/suppaftp-6.2.0/src/sync_ftp/mod.rs:463:    pub fn retr_as_stream<S: AsRef<str>>(&mut self, file_name: S) -> FtpResult<DataStream<T>> {
+/home/paul/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/suppaftp-6.2.0/src/async_ftp/mod.rs:419:    pub async fn retr<S, F, U>(&mut self, file_name: S, mut reader: F) -> FtpResult<U>
+/home/paul/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/suppaftp-6.2.0/src/async_ftp/mod.rs:439:    pub async fn retr_as_stream<S: AsRef<str>>(
+async_ftp   lib.rs   regex.rs   sync_ftp           types.rs
+command.rs  list.rs  status.rs  test_container.rs
+//! # Async
+//!
+//! This module contains the definition for all async implementation of suppaftp
+mod data_stream;
+mod tls;
+use std::future::Future;
+#[cfg(not(feature = "async-secure"))]
+use std::marker::PhantomData;
+use std::net::SocketAddr;
+use std::pin::Pin;
+use std::string::String;
+use std::time::Duration;
+use async_std::io::prelude::BufReadExt;
+use async_std::io::{copy, BufReader, Read, Write};
+use async_std::net::{TcpListener, TcpStream, ToSocketAddrs};
+use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
+// export
+pub use data_stream::DataStream;
+use futures_lite::AsyncWriteExt;
+pub use tls::AsyncNoTlsStream;
+#[cfg(feature = "async-secure")]
+pub use tls::AsyncTlsConnector;
+use tls::AsyncTlsStream;
+#[cfg(feature = "async-native-tls")]
+pub use tls::{AsyncNativeTlsConnector, AsyncNativeTlsStream};
+#[cfg(feature = "async-rustls")]
+pub use tls::{AsyncRustlsConnector, AsyncRustlsStream};
+use super::regex::{EPSV_PORT_RE, MDTM_RE, SIZE_RE};
+use super::types::{FileType, FtpError, FtpResult, Mode, Response};
+use super::Status;
+use crate::command::Command;
+#[cfg(feature = "async-secure")]
+use crate::command::ProtectionLevel;
+use crate::types::Features;
+use crate::FtpStream;
+/// A function that creates a new stream for the data connection in passive mode.
+///
+/// It takes a [`SocketAddr`] and returns a [`TcpStream`].
+pub type PassiveStreamBuilder = dyn Fn(SocketAddr) -> Pin<Box<dyn Future<Output = FtpResult<TcpStream>> + Send + Sync>>
+    + Send
+    + Sync;
+/// Stream to interface with the FTP server. This interface is only for the command stream.
+pub struct ImplAsyncFtpStream<T>
+where
+    T: AsyncTlsStream,
+{
+    reader: BufReader<DataStream<T>>,
+    mode: Mode,
+    nat_workaround: bool,
+    welcome_msg: Option<String>,
+    active_timeout: Duration,
+    passive_stream_builder: Box<PassiveStreamBuilder>,
+    #[cfg(not(feature = "async-secure"))]
+    marker: PhantomData<T>,
+    #[cfg(feature = "async-secure")]
+    tls_ctx: Option<Box<dyn AsyncTlsConnector<Stream = T> + Send + Sync + 'static>>,
+    #[cfg(feature = "async-secure")]
+    domain: Option<String>,
+}
+impl<T> ImplAsyncFtpStream<T>
+where
+    T: AsyncTlsStream,
+{
+    pub async fn connect<A: ToSocketAddrs>(addr: A) -> FtpResult<Self> {
+        debug!("Connecting to server");
+        let stream = TcpStream::connect(addr)
+            .await
+            .map_err(FtpError::ConnectionError)?;
+        debug!("Established connection with server");
+        Self::connect_with_stream(stream).await
+    }
+    /// Try to connect to the remote server but with the specified timeout
+    pub async fn connect_timeout(addr: SocketAddr, timeout: Duration) -> FtpResult<Self> {
+        debug!("Connecting to server {addr}");
+        let stream = async_std::io::timeout(timeout, async move { TcpStream::connect(addr).await })
+            .await
+            .map_err(FtpError::ConnectionError)?;
+        Self::connect_with_stream(stream).await
+    }
+    /// Connect using provided configured tcp stream
+    pub async fn connect_with_stream(stream: TcpStream) -> FtpResult<Self> {
+        debug!("Established connection with server");
+        let mut ftp_stream = ImplAsyncFtpStream {
+            reader: BufReader::new(DataStream::Tcp(stream)),
+            #[cfg(not(feature = "async-secure"))]
+            marker: PhantomData {},
+            mode: Mode::Passive,
+            nat_workaround: false,
+            passive_stream_builder: Self::default_passive_stream_builder(),
+            welcome_msg: None,
+            #[cfg(feature = "async-secure")]
+            tls_ctx: None,
+            #[cfg(feature = "async-secure")]
+            domain: None,
+            active_timeout: Duration::from_secs(60),
+        };
+        debug!("Reading server response...");
+        match ftp_stream.read_response(Status::Ready).await {
+            Ok(response) => {
+                let welcome_msg = response.as_string().ok();
+                debug!("Server READY; response: {:?}", welcome_msg);
+                ftp_stream.welcome_msg = welcome_msg;
+                Ok(ftp_stream)
+            }
+            Err(err) => Err(err),
+        }
+    }
+    /// Switch to secure mode if possible (FTPS), using a provided SSL configuration.
+    /// This method does nothing if the connect is already secured.
+    ///
+    /// ## Example
+    ///
+    /// ```rust,no_run
+    /// use suppaftp::ImplAsyncFtpStream;
+    /// use suppaftp::async_native_tls::{TlsConnector, TlsStream};
+    /// use std::path::Path;
+    ///
+    /// // Create a TlsConnector
+    /// // NOTE: For custom options see <https://docs.rs/native-tls/0.2.6/native_tls/struct.TlsConnectorBuilder.html>
+    /// let mut ctx = TlsConnector::new();
+    /// let mut ftp_stream = ImplAsyncFtpStream::connect("127.0.0.1:21").await.unwrap();
+    /// let mut ftp_stream = ftp_stream.into_secure(ctx, "localhost").await.unwrap();
+    /// ```
+    #[cfg(feature = "async-secure")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "async-secure")))]
+    pub async fn into_secure(
+        mut self,
+        tls_connector: impl AsyncTlsConnector<Stream = T> + Send + Sync + 'static,
+        domain: &str,
+    ) -> FtpResult<Self> {
+        debug!("Initializing TLS auth");
+        // Ask the server to start securing data.
+        self.perform(Command::Auth).await?;
+        self.read_response(Status::AuthOk).await?;
+        debug!("TLS OK; initializing ssl stream");
+        let stream = tls_connector
+            .connect(
+                domain,
+                self.reader.into_inner().into_tcp_stream().to_owned(),
+            )
+            .await
+            .map_err(|e| FtpError::SecureError(format!("{e}")))?;
+        let mut secured_ftp_tream = ImplAsyncFtpStream {
+            reader: BufReader::new(DataStream::Ssl(Box::new(stream))),
+            mode: self.mode,
+            nat_workaround: self.nat_workaround,
+            passive_stream_builder: self.passive_stream_builder,
+            tls_ctx: Some(Box::new(tls_connector)),
+            domain: Some(String::from(domain)),
+            welcome_msg: self.welcome_msg,
+            active_timeout: self.active_timeout,
+        };
+        // Set protection buffer size
+        secured_ftp_tream.perform(Command::Pbsz(0)).await?;
+        secured_ftp_tream.read_response(Status::CommandOk).await?;
+        // Change the level of data protectio to Private
+        secured_ftp_tream
+            .perform(Command::Prot(ProtectionLevel::Private))
+            .await?;
+        secured_ftp_tream.read_response(Status::CommandOk).await?;
+        Ok(secured_ftp_tream)
+    }
+    /// Connect to remote ftps server using IMPLICIT secure connection.
+    ///
+    /// > Warning: mind that implicit ftps should be considered deprecated, if you can use explicit mode with `into_secure()`
+    ///
+    ///
+    /// ## Example
+    ///
+    /// ```rust,no_run
+    /// use suppaftp::ImplAsyncFtpStream;
+    /// use suppaftp::native_tls::{TlsConnector, TlsStream};
+    /// use std::path::Path;
+    ///
+    /// // Create a TlsConnector
+    /// // NOTE: For custom options see <https://docs.rs/native-tls/0.2.6/native_tls/struct.TlsConnectorBuilder.html>
+    /// let mut ctx = TlsConnector::new();
+    /// let mut ftp_stream = ImplAsyncFtpStream::connect_secure_implicit("127.0.0.1:990", ctx, "localhost").await.unwrap();
+    /// ```
+    #[cfg(all(feature = "async-secure", feature = "deprecated"))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(all(feature = "async-secure", feature = "deprecated")))
+    )]
+    pub async fn connect_secure_implicit<A: ToSocketAddrs>(
+        addr: A,
+        tls_connector: impl AsyncTlsConnector<Stream = T> + Send + Sync + 'static,
+        domain: &str,
+    ) -> FtpResult<Self> {
+        debug!("Connecting to server (secure)");
+        let stream = TcpStream::connect(addr)
+            .await
+            .map_err(FtpError::ConnectionError)
+            .map(|stream| {
+                debug!("Established connection with server");
+                Self {
+                    reader: BufReader::new(DataStream::Tcp(stream)),
+                    mode: Mode::Passive,
+                    nat_workaround: false,
+                    welcome_msg: None,
+                    passive_stream_builder: Self::default_passive_stream_builder(),
+                    tls_ctx: None,
+                    domain: None,
+                    active_timeout: Duration::from_secs(60),
+                }
+            })?;
+        debug!("Established connection with server");
+        debug!("TLS OK; initializing ssl stream");

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,12 +27,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "antftp"
 version = "0.1.0"
 dependencies = [
+ "async-std",
+ "clap",
  "libunftp",
  "prost",
+ "suppaftp",
  "tokio",
+ "tokio-stream",
  "tonic",
  "tonic-build",
  "unftp-sbe-anttp",
@@ -93,6 +147,124 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-attributes"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 2.5.3",
+ "futures-core",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "497c00e0fd83a72a79a39fcbd8e3e2f055d6f6c7e025f3b3d91f4f8e76527fb8"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "blocking",
+ "futures-lite",
+ "once_cell",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener 5.4.1",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-std"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8e079a4ab67ae52b7403632e4618815d6db36d2a010cfe41b02c1b1578f93b"
+dependencies = [
+ "async-attributes",
+ "async-channel 1.9.0",
+ "async-global-executor",
+ "async-io",
+ "async-lock",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -113,6 +285,12 @@ dependencies = [
  "quote",
  "syn 2.0.114",
 ]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -228,6 +406,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -253,7 +444,7 @@ dependencies = [
  "maybe-owned",
  "rustix",
  "rustix-linux-procfs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
  "winx",
 ]
 
@@ -305,12 +496,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.5.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6899ea499e3fb9305a65d5ebf6e3d2248c5fab291f300ad0a704fbe142eae31a"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b12c8b680195a62a8364d16b8447b01b6c2c8f9aaf68bee653be34d4245e238"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+
+[[package]]
 name = "cmake"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -489,7 +735,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener 5.4.1",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -570,6 +843,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -632,6 +918,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -673,6 +971,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "http"
@@ -848,6 +1152,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -880,6 +1190,38 @@ checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "lazy-regex"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5c13b6857ade4c8ee05c3c3dc97d2ab5415d691213825b90d3211c425c1f907"
+dependencies = [
+ "lazy-regex-proc_macros",
+ "once_cell",
+ "regex",
+]
+
+[[package]]
+name = "lazy-regex-proc_macros"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a95c68db5d41694cea563c86a4ba4dc02141c16ef64814108cb23def4d5438"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -948,6 +1290,9 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+dependencies = [
+ "value-bag",
+]
 
 [[package]]
 name = "matchit"
@@ -1095,6 +1440,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1164,6 +1521,31 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "piper"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -1406,7 +1788,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1606,10 +1988,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "suppaftp"
+version = "6.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "441f4af168919034b1d6d104731a014c4d987778dc98f50463347664295adf1e"
+dependencies = [
+ "async-std",
+ "async-trait",
+ "chrono",
+ "futures-lite",
+ "lazy-regex",
+ "log",
+ "pin-project",
+ "thiserror",
+]
 
 [[package]]
 name = "syn"
@@ -1666,7 +2070,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1957,6 +2361,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "uuid"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1966,6 +2376,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "value-bag"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
 
 [[package]]
 name = "version_check"
@@ -2011,6 +2427,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2040,6 +2470,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.85"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,13 @@ tokio = { version = "1", features = ["full"] }
 unftp-sbe-anttp = { version = "0.1.0", path = "crates/unftp-sbe-anttp" }
 tonic = { version = "0.12", features = ["router"] }
 prost = { version = "0.13"}
+clap = { version = "4.5.57", features = ["derive"] }
 
 [build-dependencies]
 tonic-build = { version = "0.12" }
 
 [dev-dependencies]
 unftp-sbe-anttp = { path = "crates/unftp-sbe-anttp" }
+suppaftp = { version = "6.2.0", features = ["async"] }
+tokio-stream = "0.1"
+async-std = { version = "1.13", features = ["attributes"] }

--- a/crates/unftp-sbe-anttp/Cargo.toml
+++ b/crates/unftp-sbe-anttp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unftp-sbe-anttp"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 
 [dependencies]

--- a/crates/unftp-sbe-anttp/src/ext.rs
+++ b/crates/unftp-sbe-anttp/src/ext.rs
@@ -18,9 +18,7 @@ pub trait ServerExt {
         let address = address.into();
         libunftp::ServerBuilder::new(Box::new(move || {
             let address = address.clone();
-            tokio::runtime::Handle::current().block_on(async move {
-                Anttp::new(address).await.expect("Cannot connect to AntTP")
-            })
+            Anttp::new(address).expect("Cannot connect to AntTP")
         }))
     }
 }

--- a/spec/00005_create_integration_test_to_validate_get_and_list_support.txt
+++ b/spec/00005_create_integration_test_to_validate_get_and_list_support.txt
@@ -1,0 +1,20 @@
+As a software engineer
+I want validate that I can list and get files using AntFTP
+So that I can connect a simple FTP client in read only mode and download files
+
+Given the skeleton code for GET and LIST already exist
+When confirming that GET and LIST are supported
+Then create a simple integration test to connect to the running AntFTP instance, LIST files, then GET a file
+And use the archive at 'cec7a9eb2c644b9a5de58bbcdf2e893db9f0b2acd7fc563fc849e19d1f6bd872', which should be passed in via a command line option
+And clap should be installed to support the setting of the archive to pass into 'libunftp::Server::with_anttp'
+And use suppaftp (or better) as the FTP client library
+
+Given the are likely integration test failures
+When errors occur
+Thne debug them and update unftp-sbe-anttp/src/lib.rs with any corrections needed to allow the tests to pass
+
+Implementation Notes
+
+- Place any unit tests at the bottom of the same file as the associated production code
+- Increment patch version of anttp package in Cargo.toml
+- Create a copy of this issue description and save to /spec using the name of this issue as the filename (with lower underscore case, starting with the 5 char padded issue number, e.g. 00001_issue_title.txt)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,27 @@
 use unftp_sbe_anttp::ServerExt;
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// The AntTP archive hash to use
+    #[arg(short, long, default_value = "efdcdc93db39d5ffef254f9bb3e069fc6315a1054f20a8b00343629f7773663b")]
+    archive: String,
+
+    /// The listen address for the FTP server (e.g., 127.0.0.1:2121)
+    #[arg(short = 'l', long = "listen-address", default_value = "127.0.0.1:2121")]
+    listen_address: String,
+}
 
 #[tokio::main]
 pub async fn main() {
-    let server = libunftp::Server::with_anttp("efdcdc93db39d5ffef254f9bb3e069fc6315a1054f20a8b00343629f7773663b")
+    let args = Args::parse();
+
+    let server = libunftp::Server::with_anttp(&args.archive)
         .greeting("Welcome to ANT FTP server")
         .passive_ports(50000..=65535)
         .build()
         .unwrap();
 
-    server.listen("127.0.0.1:2121").await.expect("Failed to start FTP listener");
+    server.listen(&args.listen_address).await.expect("Failed to start FTP listener");
 }

--- a/tests/get_list_integration.rs
+++ b/tests/get_list_integration.rs
@@ -1,0 +1,139 @@
+use std::net::{TcpListener};
+use std::time::Duration;
+use tokio::task::JoinHandle;
+use tokio_stream::wrappers::TcpListenerStream;
+use suppaftp::AsyncFtpStream;
+use unftp_sbe_anttp::ServerExt;
+
+// Generated from proto (provided by unftp-sbe-anttp crate)
+use unftp_sbe_anttp::proto::public_archive::public_archive_service_server::{PublicArchiveService, PublicArchiveServiceServer};
+use unftp_sbe_anttp::proto::public_archive::{GetPublicArchiveRequest, GetPublicArchiveResponse};
+use tonic::{Request, Response, Status};
+
+struct MockArchiveService;
+
+#[tonic::async_trait]
+impl PublicArchiveService for MockArchiveService {
+    async fn create_public_archive(
+        &self,
+        _request: Request<unftp_sbe_anttp::proto::public_archive::CreatePublicArchiveRequest>,
+    ) -> Result<Response<unftp_sbe_anttp::proto::public_archive::PublicArchiveResponse>, Status> {
+        Err(Status::unimplemented("not needed for this test"))
+    }
+
+    async fn update_public_archive(
+        &self,
+        _request: Request<unftp_sbe_anttp::proto::public_archive::UpdatePublicArchiveRequest>,
+    ) -> Result<Response<unftp_sbe_anttp::proto::public_archive::PublicArchiveResponse>, Status> {
+        Err(Status::unimplemented("not needed for this test"))
+    }
+
+    async fn truncate_public_archive(
+        &self,
+        _request: Request<unftp_sbe_anttp::proto::public_archive::TruncatePublicArchiveRequest>,
+    ) -> Result<Response<unftp_sbe_anttp::proto::public_archive::PublicArchiveResponse>, Status> {
+        Err(Status::unimplemented("not needed for this test"))
+    }
+
+    async fn get_public_archive(
+        &self,
+        request: Request<GetPublicArchiveRequest>,
+    ) -> Result<Response<GetPublicArchiveResponse>, Status> {
+        let req = request.into_inner();
+        // Root listing
+        if req.path.is_empty() || req.path == "/" {
+            Ok(Response::new(GetPublicArchiveResponse {
+                address: Some(req.address.clone()),
+                items: vec!["file1.txt".to_string(), "dir".to_string()],
+                content: None,
+            }))
+        } else if req.path == "/file1.txt" || req.path == "file1.txt" {
+            Ok(Response::new(GetPublicArchiveResponse {
+                address: Some(req.address.clone()),
+                items: vec![],
+                content: Some(b"hello world".to_vec()),
+            }))
+        } else {
+            // Unknown path
+            Ok(Response::new(GetPublicArchiveResponse {
+                address: Some(req.address.clone()),
+                items: vec![],
+                content: None,
+            }))
+        }
+    }
+}
+
+async fn start_mock_grpc() -> (String, JoinHandle<()>) {
+    let std_listener = TcpListener::bind("127.0.0.1:0").expect("bind mock grpc");
+    std_listener.set_nonblocking(true).expect("nonblocking");
+    let addr = std_listener.local_addr().unwrap();
+    let incoming = TcpListenerStream::new(tokio::net::TcpListener::from_std(std_listener).unwrap());
+
+    let svc = PublicArchiveServiceServer::new(MockArchiveService);
+    let handle = tokio::spawn(async move {
+        tonic::transport::Server::builder()
+            .add_service(svc)
+            .serve_with_incoming(incoming)
+            .await
+            .unwrap();
+    });
+
+    (format!("http://{}", addr), handle)
+}
+
+fn start_ftp_server(archive: &str, addr: &str) -> std::thread::JoinHandle<()> {
+    let server = libunftp::Server::with_anttp(archive)
+        .greeting("Welcome to ANT FTP server")
+        .passive_ports(50000..=65535)
+        .build()
+        .unwrap();
+    let addr = addr.to_string();
+    std::thread::spawn(move || {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async move {
+            server.listen(&addr).await.unwrap();
+        });
+    })
+}
+
+#[tokio::test]
+async fn integration_list_and_get() {
+    // 1) Start mock gRPC
+    let (grpc_endpoint, _grpc_handle) = start_mock_grpc().await;
+    unsafe { std::env::set_var("ANTTP_GRPC_ENDPOINT", &grpc_endpoint); }
+
+    // 2) Pick random FTP port
+    let ftp_listener = TcpListener::bind("127.0.0.1:0").expect("bind ftp");
+    let ftp_addr = ftp_listener.local_addr().unwrap();
+    drop(ftp_listener); // release so libunftp can bind
+    let ftp_addr_str = format!("{}:{}", ftp_addr.ip(), ftp_addr.port());
+
+    // 3) Start FTP server
+    let _ftp_handle = start_ftp_server(
+        "cec7a9eb2c644b9a5de58bbcdf2e893db9f0b2acd7fc563fc849e19d1f6bd872",
+        &ftp_addr_str,
+    );
+
+    // 4) Give server a moment to start
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    // 5) Connect with suppaftp
+    let addr = format!("{}:{}", ftp_addr.ip(), ftp_addr.port());
+    let mut ftp_stream = AsyncFtpStream::connect(addr).await.expect("connect ftp");
+    ftp_stream.login("anonymous", "anonymous").await.expect("login");
+
+    // 6) List root
+    let list = ftp_stream.nlst(None).await.expect("nlst");
+    assert!(list.contains(&"file1.txt".to_string()));
+
+    // 7) Retrieve file
+    let mut stream = ftp_stream.retr_as_stream("file1.txt").await.expect("retr_as_stream");
+    let mut data = Vec::new();
+    use async_std::io::ReadExt as _;
+    stream.read_to_end(&mut data).await.expect("read_to_end");
+    ftp_stream.finalize_retr_stream(stream).await.expect("finalize_retr_stream");
+    assert_eq!(data, b"hello world");
+
+    ftp_stream.quit().await.ok();
+}


### PR DESCRIPTION
Implements integration testing for GET and LIST support and related enhancements. Fixes #5.

Summary of changes:

- Add clap-powered CLI options:
  - `-a, --archive <HASH>`: archive hash to pass into `libunftp::Server::with_anttp`
  - `-l, --listen-address <ADDR>`: listen address for the FTP server (default `127.0.0.1:2121`)
- Add a mock gRPC `PublicArchiveService` for integration testing and an integration test `tests/get_list_integration.rs` using `suppaftp` to:
  - Start a mock tonic gRPC server on a random port
  - Start the FTP server on a random port
  - LIST the root directory and verify file presence
  - GET a file and verify returned content
- Ensure all gRPC calls set `store_type = "memory"` (per issue update) and make the gRPC endpoint configurable via `ANTTP_GRPC_ENDPOINT`.
- Make AntTP client construction non-async using `tonic::transport::Channel::connect_lazy()` to avoid nested runtime issues in tests.
- Expose the `proto` module from `unftp-sbe-anttp` to enable mock server implementation in tests.
- Bump `unftp-sbe-anttp` patch version to `0.1.2`.
- Add a copy of the issue to `/spec/00005_create_integration_test_to_validate_get_and_list_support.txt`.

Testing:

- `cargo test -p antftp --test get_list_integration` passes locally.
- `cargo test` for the workspace passes locally.

Notes:

- The gRPC endpoint defaults to `http://localhost:18887` but can be overridden in tests/CI with `ANTTP_GRPC_ENDPOINT`.
- The mock server assumes the test archive exists and returns a deterministic file listing and content consistent with the issue requirements.

Please review and let me know if you want any adjustments (e.g., different file names, additional assertions, or expanding the mock).