### PR TITLE
Add support for PUT and MKD FTP command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2323,7 +2323,7 @@ checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "unftp-sbe-anttp"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "async-trait",
  "cap-std",

--- a/crates/unftp-sbe-anttp/Cargo.toml
+++ b/crates/unftp-sbe-anttp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unftp-sbe-anttp"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 
 [dependencies]

--- a/spec/00009_add_support_for_put_and_mkd_ftp_command.txt
+++ b/spec/00009_add_support_for_put_and_mkd_ftp_command.txt
@@ -1,0 +1,31 @@
+As a software engineer
+I want support for MKD and PUT FTP commands
+So that I can add files and directories to an archive with an FTP client
+
+Given there are a list of FTP functions in crates/unftp_sbe_anttp/src/lib.rs
+When integrating with AntTP over protobuf
+Then implement PUT function using protobuf RPC calls as defined in /proto/public_archive.proto
+And use UpdatePublicArchive RPC to add the file or directory
+And don't implement other endpoints yet in this task
+
+Given the address of the archive changes after it has been modified
+When a file is added to the archive
+Then store the new address as the archive being used for all FTP commands
+And then the user experience will seem like the archive was just updated
+And continue to use store-type = memory
+
+Given AntTP (and Autonomi) don't support creating empty directories in archives
+When a new directory is created using MKD
+Then create a hidden (.metadata) file in the target directory using UpdatePublicArchive
+And then the directory will appear to be created and other files can then be added by a client 
+
+Given testing would improve quality
+When adding the PUT command
+Then update the unit tests and integration tests to reflect the new DEL command
+
+Implementation Notes
+
+- Place any unit tests at the bottom of the same file as the associated production code
+- Increment patch version of anttp package in Cargo.toml
+- Create a copy of this issue description and save to /spec using the name of this issue as the filename (with lower underscore case, starting with the 5 char padded issue number, e.g. 00001_issue_title.txt)
+- Implement basic unit tests

--- a/tests/get_list_integration.rs
+++ b/tests/get_list_integration.rs
@@ -23,9 +23,14 @@ impl PublicArchiveService for MockArchiveService {
 
     async fn update_public_archive(
         &self,
-        _request: Request<unftp_sbe_anttp::proto::public_archive::UpdatePublicArchiveRequest>,
+        request: Request<unftp_sbe_anttp::proto::public_archive::UpdatePublicArchiveRequest>,
     ) -> Result<Response<unftp_sbe_anttp::proto::public_archive::PublicArchiveResponse>, Status> {
-        Err(Status::unimplemented("not needed for this test"))
+        let req = request.into_inner();
+        let mut new_address = req.address;
+        new_address.push_str("_updated");
+        Ok(Response::new(unftp_sbe_anttp::proto::public_archive::PublicArchiveResponse {
+            address: Some(new_address),
+        }))
     }
 
     async fn truncate_public_archive(
@@ -147,6 +152,43 @@ async fn integration_list_and_get() {
     stream.read_to_end(&mut data).await.expect("read_to_end");
     ftp_stream.finalize_retr_stream(stream).await.expect("finalize_retr_stream");
     assert_eq!(data, b"hello world");
+
+    ftp_stream.quit().await.ok();
+}
+
+#[tokio::test]
+async fn integration_put_and_mkd() {
+    // 1) Start mock gRPC
+    let (grpc_endpoint, _grpc_handle) = start_mock_grpc().await;
+    unsafe { std::env::set_var("ANTTP_GRPC_ENDPOINT", &grpc_endpoint); }
+
+    // 2) Pick random FTP port
+    let ftp_listener = TcpListener::bind("127.0.0.1:0").expect("bind ftp");
+    let ftp_addr = ftp_listener.local_addr().unwrap();
+    drop(ftp_listener); // release so libunftp can bind
+    let ftp_addr_str = format!("{}:{}", ftp_addr.ip(), ftp_addr.port());
+
+    // 3) Start FTP server
+    let initial_address = "cec7a9eb2c644b9a5de58bbcdf2e893db9f0b2acd7fc563fc849e19d1f6bd872";
+    let _ftp_handle = start_ftp_server(
+        initial_address,
+        &ftp_addr_str,
+    );
+
+    // 4) Give server a moment to start
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    // 5) Connect with suppaftp
+    let mut ftp_stream = AsyncFtpStream::connect(&ftp_addr_str).await.expect("connect ftp");
+    ftp_stream.login("anonymous", "anonymous").await.expect("login");
+
+    // 6) Test MKD
+    ftp_stream.mkdir("new_dir").await.expect("mkdir");
+    
+    // 7) Test PUT
+    let content = b"new file content";
+    let mut reader = content.as_slice();
+    ftp_stream.put_file("new_file.txt", &mut reader).await.expect("put_file");
 
     ftp_stream.quit().await.ok();
 }


### PR DESCRIPTION
Resolves issue #9.

Implemented support for PUT and MKD FTP commands in `unftp-sbe-anttp` storage backend.

Key changes:
- Updated `Anttp` struct to use `Arc<RwLock<String>>` for the archive address to allow persistent updates across connections.
- Implemented `put` using `UpdatePublicArchive` gRPC call.
- Implemented `mkd` (mkdir) by creating a `.metadata` file in the target directory via `UpdatePublicArchive`.
- Ensured the archive address is updated in memory after any modification.
- Incremented `unftp-sbe-anttp` version to `0.1.3`.
- Updated integration tests in `tests/get_list_integration.rs` to verify PUT and MKD functionality.
- Added issue description to `spec/00009_add_support_for_put_and_mkd_ftp_command.txt`.