### PR TITLE
Final Update: Tarchive and Public Archive Protos (Issue #12)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2323,7 +2323,7 @@ checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "unftp-sbe-anttp"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "async-trait",
  "cap-std",

--- a/crates/unftp-sbe-anttp/Cargo.toml
+++ b/crates/unftp-sbe-anttp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unftp-sbe-anttp"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 
 [dependencies]

--- a/proto/public_archive.proto
+++ b/proto/public_archive.proto
@@ -12,18 +12,19 @@ service PublicArchiveService {
 message File {
   string name = 1;
   bytes content = 2;
-  optional string target_path = 3;
 }
 
 message CreatePublicArchiveRequest {
   repeated File files = 1;
-  optional string store_type = 2;
+  optional string path = 2;
+  optional string store_type = 3;
 }
 
 message UpdatePublicArchiveRequest {
   string address = 1;
   repeated File files = 2;
-  optional string store_type = 3;
+  optional string path = 3;
+  optional string store_type = 4;
 }
 
 message TruncatePublicArchiveRequest {

--- a/proto/tarchive.proto
+++ b/proto/tarchive.proto
@@ -10,18 +10,19 @@ service TarchiveService {
 message File {
   string name = 1;
   bytes content = 2;
-  optional string target_path = 3;
 }
 
 message CreateTarchiveRequest {
   repeated File files = 1;
-  optional string store_type = 2;
+  optional string path = 2;
+  optional string store_type = 3;
 }
 
 message UpdateTarchiveRequest {
   string address = 1;
   repeated File files = 2;
-  optional string store_type = 3;
+  optional string path = 3;
+  optional string store_type = 4;
 }
 
 message TarchiveResponse {

--- a/spec/00012_update_tarchive_and_public_archive_protos_and_impacted_code.txt
+++ b/spec/00012_update_tarchive_and_public_archive_protos_and_impacted_code.txt
@@ -1,0 +1,22 @@
+Update tarchive and public archive protos and impacted code
+
+As a software engineer
+I want update the proto files for public_archive.proto and tarchive.proto to the latest version
+So that I can take advantage of their latest features
+
+Given there are new protobufs for archives
+When upgrading protos
+Then download https://github.com/traktion/AntTP/blob/master/proto/public_archive.proto for public archives
+And download https://github.com/traktion/AntTP/blob/master/proto/tarchive.proto for tarchives
+And update dependencies to reflect the changes
+
+Given path handling is different in the new protos
+When updating protos
+Then update PUT and MKD FTP commands in lib.rs to correctly set the path for all files
+
+Implementation Notes
+
+- Place any unit tests at the bottom of the same file as the associated production code
+- Increment patch version of anttp package in Cargo.toml
+- Create a copy of this issue description and save to /spec using the name of this issue as the filename (with lower underscore case, starting with the 5 char padded issue number, e.g. 00012_update_tarchive_and_public_archive_protos_and_impacted_code.txt)
+- Implement basic unit tests

--- a/tests/get_list_integration.rs
+++ b/tests/get_list_integration.rs
@@ -26,6 +26,20 @@ impl PublicArchiveService for MockArchiveService {
         request: Request<unftp_sbe_anttp::proto::public_archive::UpdatePublicArchiveRequest>,
     ) -> Result<Response<unftp_sbe_anttp::proto::public_archive::PublicArchiveResponse>, Status> {
         let req = request.into_inner();
+        
+        // Basic validation of the new proto structure
+        if req.path.is_none() {
+            return Err(Status::invalid_argument("path is required in the new proto"));
+        }
+
+        let path = req.path.as_ref().unwrap();
+        if path.ends_with("new_file.txt") {
+            let file = &req.files[0];
+            if file.name != "new_file.txt" {
+                return Err(Status::invalid_argument(format!("Expected filename 'new_file.txt', got '{}'", file.name)));
+            }
+        }
+
         let mut new_address = req.address;
         new_address.push_str("_updated");
         Ok(Response::new(unftp_sbe_anttp::proto::public_archive::PublicArchiveResponse {
@@ -134,14 +148,14 @@ async fn integration_list_and_get() {
     );
 
     // 4) Give server a moment to start
-    tokio::time::sleep(Duration::from_millis(300)).await;
+    tokio::time::sleep(Duration::from_millis(500)).await;
 
     // 5) Connect with suppaftp
     let addr = format!("{}:{}", ftp_addr.ip(), ftp_addr.port());
     let mut ftp_stream = AsyncFtpStream::connect(addr).await.expect("connect ftp");
     ftp_stream.login("anonymous", "anonymous").await.expect("login");
 
-    // 6) List root
+    // Root listing
     let list = ftp_stream.nlst(None).await.expect("nlst");
     assert!(list.iter().any(|item| item == "file1.txt"));
 
@@ -176,7 +190,7 @@ async fn integration_put_and_mkd() {
     );
 
     // 4) Give server a moment to start
-    tokio::time::sleep(Duration::from_millis(300)).await;
+    tokio::time::sleep(Duration::from_millis(500)).await;
 
     // 5) Connect with suppaftp
     let mut ftp_stream = AsyncFtpStream::connect(&ftp_addr_str).await.expect("connect ftp");


### PR DESCRIPTION
Resolves #12

This PR provides the final implementation for issue #12, updating the protos and adjusting the storage backend to match the new structure.

### Changes:
- Updated `proto/public_archive.proto` and `proto/tarchive.proto` to the latest versions.
- Removed `target_path` and added `path` field to gRPC messages.
- Updated `put` and `mkd` in `unftp-sbe-anttp` to use the new `path` and `name` fields correctly.
- Incremented `unftp-sbe-anttp` version to `0.1.4`.
- Improved integration test stability by increasing startup delay.
- Added specification file `spec/00012_update_tarchive_and_public_archive_protos_and_impacted_code.txt`.