### PR TITLE
Add logging and improve documentation (#24)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,11 +78,13 @@ dependencies = [
 
 [[package]]
 name = "antftp"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "async-std",
  "clap",
+ "env_logger",
  "libunftp",
+ "log",
  "prost",
  "rustls",
  "serial_test",
@@ -716,6 +718,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "env_filter"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bf3c259d255ca70051b30e2e95b5446cdb8949ac4cd22c0d7fd634d89f568e2"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1186,6 +1211,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "jiff"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89a5b5e10d5a9ad6e5d1f4bd58225f655d6fe9767575a5e8ac5a6fe64e04495"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff7a39c8862fc1369215ccf0a8f12dd4598c7f6484704359f0351bd617034dbf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1565,6 +1614,15 @@ name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "powerfmt"
@@ -2376,7 +2434,7 @@ checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "unftp-sbe-anttp"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "async-trait",
  "cap-std",
@@ -2384,6 +2442,7 @@ dependencies = [
  "futures",
  "lazy_static",
  "libunftp",
+ "log",
  "prost",
  "tokio",
  "tokio-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "antftp"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 
 [dependencies]
@@ -11,6 +11,8 @@ unftp-sbe-anttp = { version = "0.1.0", path = "crates/unftp-sbe-anttp" }
 tonic = { version = "0.12", features = ["router"] }
 prost = { version = "0.13"}
 clap = { version = "4.5.57", features = ["derive"] }
+log = "0.4"
+env_logger = "0.11"
 
 [build-dependencies]
 tonic-build = { version = "0.12" }

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ You can run AntFTP with the following arguments:
 - `-a`, `--archive <ARCHIVE>`: The AntTP archive hash to use. (Default: `efdcdc93db39d5ffef254f9bb3e069fc6315a1054f20a8b00343629f7773663b`)
 - `-p`, `--pointer-name <POINTER_NAME>`: Optional pointer name to resolve the archive address from AntTP.
 - `-l`, `--listen-address <LISTEN_ADDRESS>`: The address and port the FTP server will listen on. (Default: `127.0.0.1:2121`)
+- `-n`, `--network-sync-timer <MINUTES>`: Network sync interval in minutes. Only used when a pointer is provided. (Default: `10`)
+
+### Network Syncing
+When a pointer name is provided via `-p`, AntFTP periodically synchronizes the current archive state to the Autonomi network. The sync timer (`-n`) determines how often (in minutes) AntFTP checks if the archive has changed and pushes any updates to the network. This ensures that your data is eventually persisted to the decentralized network while allowing for fast, local-first iterations.
 
 Example:
 ```bash
@@ -73,6 +77,15 @@ You can use `rclone` to mount an AntTP archive as a local file system via AntFTP
    ```
 
 Now you can browse your AntTP archive as if it were a local directory.
+
+## Logging
+AntFTP uses `env_logger` for logging. You can control the log level using the `RUST_LOG` environment variable.
+
+Example:
+```bash
+RUST_LOG=info ./antftp
+```
+To see detailed FTP command logs, use `RUST_LOG=debug`.
 
 ## Limitations
 

--- a/crates/unftp-sbe-anttp/Cargo.toml
+++ b/crates/unftp-sbe-anttp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unftp-sbe-anttp"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2024"
 
 [dependencies]
@@ -14,6 +14,7 @@ tokio = { version = "1.48.0", features = ["rt", "net", "sync", "io-util", "time"
 tokio-stream = "0.1.17"
 tonic = { version = "0.12" }
 prost = { version = "0.13" }
+log = "0.4"
 
 [build-dependencies]
 tonic-build = "0.12"

--- a/crates/unftp-sbe-anttp/src/lib.rs
+++ b/crates/unftp-sbe-anttp/src/lib.rs
@@ -11,6 +11,7 @@ use std::fmt::Debug;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::SystemTime;
+use log::debug;
 use tokio::io::AsyncReadExt;
 use tokio::sync::RwLock;
 use tonic::transport::Channel;
@@ -124,6 +125,7 @@ impl<User: UserDetail> StorageBackend<User> for Anttp {
     }
 
     async fn metadata<P: AsRef<Path> + Send + Debug>(&self, _user: &User, path: P) -> Result<Self::Metadata> {
+        debug!("FTP command: METADATA for path {:?}", path.as_ref());
         self.resolve_pointer().await?;
         let mut path_str = path.as_ref().to_string_lossy().into_owned();
         if path_str == "." {
@@ -158,6 +160,7 @@ impl<User: UserDetail> StorageBackend<User> for Anttp {
     where
         P: AsRef<Path> + Send + Debug,
     {
+        debug!("FTP command: LIST for path {:?}", path.as_ref());
         self.resolve_pointer().await?;
         let path_str = path.as_ref().to_string_lossy().into_owned();
         let mut client = self.client.clone();
@@ -194,6 +197,7 @@ impl<User: UserDetail> StorageBackend<User> for Anttp {
     }
 
     async fn get<P: AsRef<Path> + Send + Debug>(&self, _user: &User, path: P, _start_pos: u64) -> Result<Box<dyn tokio::io::AsyncRead + Send + Sync + Unpin>> {
+        debug!("FTP command: GET for path {:?}", path.as_ref());
         self.resolve_pointer().await?;
         let path_str = path.as_ref().to_string_lossy().into_owned();
         let mut client = self.client.clone();
@@ -225,6 +229,7 @@ impl<User: UserDetail> StorageBackend<User> for Anttp {
         path: P,
         _start_pos: u64,
     ) -> Result<u64> {
+        debug!("FTP command: PUT for path {:?}", path.as_ref());
         let mut content = Vec::new();
         bytes.read_to_end(&mut content).await
             .map_err(|e| Error::new(ErrorKind::LocalError, e))?;
@@ -262,6 +267,7 @@ impl<User: UserDetail> StorageBackend<User> for Anttp {
     }
 
     async fn del<P: AsRef<Path> + Send + Debug>(&self, _user: &User, path: P) -> Result<()> {
+        debug!("FTP command: DEL for path {:?}", path.as_ref());
         let path_str = path.as_ref().to_string_lossy().into_owned();
         let mut client = self.client.clone();
         let mut address_guard = self.address.write().await;
@@ -292,6 +298,7 @@ impl<User: UserDetail> StorageBackend<User> for Anttp {
     }
 
     async fn mkd<P: AsRef<Path> + Send + Debug>(&self, _user: &User, path: P) -> Result<()> {
+        debug!("FTP command: MKD for path {:?}", path.as_ref());
         let path_str = path.as_ref().to_string_lossy().into_owned();
         
         let mut client = self.client.clone();

--- a/spec/00024_add_logging_and_improve_documentation.txt
+++ b/spec/00024_add_logging_and_improve_documentation.txt
@@ -1,0 +1,19 @@
+As an AntFTP user
+I want to see logs for each command that is executed and each time the data is synced to the Autonomi network
+So that it is easy to observe application behaviour
+
+Given logging is needed to explain what the application is doing
+When adding logging
+Then add 'log' dependency
+And add log output for each FTP command and for each time the archive/pointer is synced to the Autonomi network
+
+Given there are additional command line options
+When making these changes
+Then improve README.md to include the sync timer details
+And an explanation of what the sync timer does
+
+Implementation Notes
+
+- Place any unit tests at the bottom of the same file as the associated production code
+- Increment patch version of anttp package in Cargo.toml
+- Create a copy of this issue description and save to /spec using the name of this issue as the filename (with lower underscore case, starting with the 5 char padded issue number, e.g. 00001_issue_title.txt)


### PR DESCRIPTION
Resolves #24

Summary of changes:
- Added `log` and `env_logger` dependencies.
- Initialized `env_logger` in `main.rs`.
- Added `info!` and `error!` logs for archive/pointer network synchronization in `main.rs`.
- Added `debug!` logs for each FTP command in the `unftp-sbe-anttp` storage backend.
- Improved `README.md` to include documentation for the network sync timer and logging.
- Incremented patch versions for `antftp` and `unftp-sbe-anttp`.
- Saved issue description to `spec/00024_add_logging_and_improve_documentation.txt`.